### PR TITLE
[13.0][FIX] account_invoice_margin: Avoid error when trying to install module with database populated with many invoices

### DIFF
--- a/account_invoice_margin/__init__.py
+++ b/account_invoice_margin/__init__.py
@@ -1,5 +1,6 @@
 # © 2017 Sergio Teruel <sergio.teruel@tecnativa.com>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
+from .hooks import pre_init_hook
 from . import models
 from . import report

--- a/account_invoice_margin/__manifest__.py
+++ b/account_invoice_margin/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Account Invoice Margin",
     "summary": "Show margin in invoices",
-    "version": "13.0.1.2.0",
+    "version": "13.0.1.2.1",
     "category": "Account",
     "website": "https://www.github.com/OCA/margin-analysis",
     "author": "Tecnativa, " "GRAP, " "Odoo Community Association (OCA)",
@@ -18,4 +18,5 @@
         "security/account_invoice_margin_security.xml",
         "views/account_invoice_margin_view.xml",
     ],
+    "pre_init_hook": "pre_init_hook",
 }

--- a/account_invoice_margin/hooks.py
+++ b/account_invoice_margin/hooks.py
@@ -1,0 +1,56 @@
+import logging
+
+from odoo.tools import column_exists, create_column
+
+_logger = logging.getLogger(__name__)
+
+COLUMNS = (
+    ("account_move", "margin"),
+    ("account_move", "margin_signed"),
+    ("account_move", "margin_percent"),
+    ("account_move_line", "margin"),
+    ("account_move_line", "margin_signed"),
+    ("account_move_line", "margin_percent"),
+    ("account_move_line", "purchase_price"),
+)
+
+
+def pre_init_hook(cr):
+    for table, column in COLUMNS:
+        if not column_exists(cr, table, column):
+            _logger.info("Create column %s in database", column)
+            create_column(cr, table, column, "numeric")
+    cr.execute(
+        """
+        WITH am AS(
+            SELECT id FROM account_move WHERE type NOT ILIKE 'in_%'
+        )
+        UPDATE account_move_line
+            SET margin = price_subtotal, margin_signed = price_subtotal,
+                margin_percent = 100
+        FROM am
+        WHERE am.id = account_move_line.move_id
+        AND price_subtotal > 0.0;
+    """
+    )
+    cr.execute(
+        """
+        WITH aml AS(
+            SELECT
+               account_move_line.move_id,
+               SUM(account_move_line.margin) AS sum_margin,
+               SUM(account_move_line.margin_signed) AS sum_margin_signed
+            FROM account_move_line
+            INNER JOIN account_move
+            ON account_move.id = account_move_line.move_id
+            GROUP BY account_move_line.move_id
+        )
+        UPDATE account_move
+            SET margin = aml.sum_margin,
+                margin_signed = aml.sum_margin_signed,
+                margin_percent = aml.sum_margin_signed / amount_untaxed * 100
+        FROM aml
+        WHERE account_move.id = aml.move_id
+        AND account_move.amount_untaxed > 0.0
+    """
+    )

--- a/account_invoice_margin/tests/test_account_invoice_margin.py
+++ b/account_invoice_margin/tests/test_account_invoice_margin.py
@@ -69,6 +69,28 @@ class TestAccountInvoiceMargin(SavepointCase):
                 ],
             }
         )
+        cls.vendor_bill = cls.env["account.move"].create(
+            {
+                "partner_id": cls.partner.id,
+                "invoice_date": fields.Date.from_string("2017-06-19"),
+                "type": "in_invoice",
+                "currency_id": cls.env.user.company_id.currency_id.id,
+                "invoice_line_ids": [
+                    (
+                        0,
+                        None,
+                        {
+                            "product_id": cls.product.id,
+                            "product_uom_id": cls.product.uom_id.id,
+                            "account_id": cls.product.property_account_receivable_id.id,
+                            "name": "Test Margin",
+                            "price_unit": cls.product.list_price,
+                            "quantity": 10,
+                        },
+                    )
+                ],
+            }
+        )
 
     def test_invoice_margin(self):
         self.assertEqual(self.invoice.invoice_line_ids.purchase_price, 100.00)
@@ -78,6 +100,10 @@ class TestAccountInvoiceMargin(SavepointCase):
             check_move_validity=False
         ).discount = 50
         self.assertEqual(self.invoice.invoice_line_ids.margin, 0.0)
+
+    def test_vendor_bill_margin(self):
+        self.assertEqual(self.vendor_bill.invoice_line_ids.purchase_price, 0.00)
+        self.assertEqual(self.vendor_bill.invoice_line_ids.margin, 0.00)
 
     def test_invoice_margin_uom(self):
         inv_line = self.invoice.invoice_line_ids


### PR DESCRIPTION
Currently, when the module is installed in a database populated with invoices, the compute methods are 
executed when fields are created, if the number of records is not many, the fields are set correctly, the problem 
lies when the records of these invoice lines are a considerable count (for example > 400 thousand AML records) 
does not finish running the compute methods and the odoo server closes unexpectedly, causing the module to 
fail to install.

![Selección_999(603)](https://user-images.githubusercontent.com/16093067/134244220-c88c6d29-c6f7-4966-9e7e-5e35ad746f78.png)


In order to solve this problem, it was required to create a hook to create the fields, to avoid the execution of 
the computed methods and in this way the installation of the module culminates successfully.

![Selección_999(604)](https://user-images.githubusercontent.com/16093067/134248666-5019d70a-c31c-4ab4-bf2a-b043ed738601.png)

